### PR TITLE
Feature: Add news from USA

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -1,13 +1,13 @@
 import React, { useState, useEffect } from "react";
 import { Routes, Route, useLocation } from "react-router-dom";
 import "./App.css";
-import { world } from "../api-calls/api-calls";
+import { world, usa } from "../api-calls/api-calls";
 import Header from '../Header/Header';
 import Home from "../Home/Home";
 import StoryDetail from "../StoryDetail/StoryDetail";
 
 function App() {
-  const [worldNews, setWorldNews] = useState([]);
+  const [allNews, setNews] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -16,11 +16,15 @@ function App() {
    useEffect(() => {
     window.scrollTo(0, 0);
   }, [location]);
-  
+
   useEffect(() => {
-    world()
-      .then((data) => {
-        setWorldNews(data.articles);
+    Promise.all([world(), usa()])
+      .then((allData) => {
+        const worldNews = allData[0].articles;
+        const usaNews = allData[1].articles;
+        const combinedNews = [...worldNews, ...usaNews];
+
+        setNews(combinedNews);
         setIsLoading(false);
       })
       .catch((err) => {
@@ -43,10 +47,10 @@ function App() {
         <Routes>
           <Route 
             path="/" 
-            element={<Home worldNews={worldNews}/>} />
+            element={<Home allNews={allNews}/>} />
           <Route
             path="/:id/:title"
-            element={<StoryDetail worldNews={worldNews}/>} />
+            element={<StoryDetail allNews={allNews}/>} />
         </Routes>
      
     </div>

--- a/src/Home/Home.js
+++ b/src/Home/Home.js
@@ -2,20 +2,18 @@ import '../Home/Home.css';
 import Card from '../Card/Card'
 
 
-function Home({worldNews}) {
+function Home({allNews}) {
 
   return (
      <main>
         <h1>Recent Headlines</h1>
         <div className="Home">
-          {worldNews.map((article) => (
+          {allNews.map((article) => (
             <Card key={article.id} article={article} />
           ))}
         </div>
       </main>
   )
 }
-
-
 
 export default Home;

--- a/src/StoryDetail/StoryDetail.js
+++ b/src/StoryDetail/StoryDetail.js
@@ -3,9 +3,9 @@ import { useParams } from "react-router-dom";
 import { Link } from 'react-router-dom';
 
 
-function StoryDetail({ worldNews }) {
+function StoryDetail({ allNews }) {
   let { id } = useParams();
-  const article =worldNews.find(article => article.id === id);
+  const article = allNews.find(article => article.id === id);
 
   if (!article) {
     return (

--- a/src/api-calls/api-calls.js
+++ b/src/api-calls/api-calls.js
@@ -2,9 +2,11 @@ import { v4 as uuidv4 } from 'uuid';
 
 const todaysDate = new Date()
 const todayQuery = todaysDate.toISOString().split("T")[0];
-//World
+
+//World News
 export const world = () => {
-  return fetch('https://newsapi.org/v2/everything?q=energy%20And%20clean&domains=washingtonpost.com,bbc.co.uk&apiKey=ec4aaf5184104872884ca453b6fe31b1')
+  return fetch(`https://newsapi.org/v2/everything?q=energy AND (solar OR wind OR clean OR green OR "climate change")&searchIn
+=title,content&domains=bbc.co.uk,reuters.com,aljazeera.com,thenextweb.com&from=${todayQuery}&to=2023-07-31&apiKey=1520e94979fc4ab78930a5f2fd259b01`)
     .then(response => {
       if (response.ok) {
         return response.json();
@@ -23,4 +25,27 @@ export const world = () => {
       return data;
       });
     }
+
+//USA News
+export const usa = () => {
+  return fetch(`https://newsapi.org/v2/everything?q=energy AND (solar OR wind OR clean OR green OR "climate change")&domains=washingtonpost.com,denverpost.com,latimes.com,usatoday.com&from=${todayQuery}&to=2023-07-30&apiKey=1520e94979fc4ab78930a5f2fd259b01`)
+   .then(response => {
+      if (response.ok) {
+        return response.json();
+      } else {
+        throw new Error('Error: ' + response.status);
+      }
+    })
+    .then(data => {
+      data.articles.forEach(article => {
+        article.type = 'USA';
+        article.id = uuidv4();
+        let date = new Date(article.publishedAt);
+        let formattedDate = `${date.toLocaleString( 'default', { month: 'long'})} ${date.getDate()}`;
+        article.formattedDate = formattedDate;
+      });
+      return data;
+      });
+    }
+    
 


### PR DESCRIPTION
## Description
- new fetch call to get USA news
- creates cards with the | USA tag

## Notes
- searches through The Washington Post, Denver Post, Los Angeles Times, USA Today
- includes some articles that don't seem to be climate or green energy related, including the api doc's recommendation to limit it to related articles did not make a difference. Would need more refining to ensure this was taken care of.

![image](https://github.com/CBradsen/green-news-app/assets/117617970/653455c8-249f-4877-b66e-f31079d7cbbe)
